### PR TITLE
Add organisers sections and update hub locations

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -334,6 +334,96 @@ section {
     margin-bottom: 1rem;
 }
 
+/* Organisers Section */
+.organisers-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.organiser-card {
+    background-color: #f9f9f9;
+    padding: 2rem;
+    border-radius: var(--border-radius);
+    text-align: center;
+    box-shadow: var(--box-shadow);
+    transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.organiser-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.organiser-card h3 {
+    color: var(--primary-color);
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.organiser-card .affiliation {
+    color: var(--dark-gray);
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    font-style: italic;
+}
+
+.organiser-card .email {
+    font-size: 0.95rem;
+    color: var(--text-color);
+}
+
+.organiser-card .email i {
+    color: var(--primary-color);
+    margin-right: 0.5rem;
+}
+
+.organiser-card .email a {
+    color: var(--primary-color);
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+.organiser-card .email a:hover {
+    color: var(--secondary-color);
+    text-decoration: underline;
+}
+
+/* Local Hub Organisers Section */
+.local-hub-organisers-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.hub-organiser-card {
+    background-color: #f9f9f9;
+    padding: 1.5rem;
+    border-radius: var(--border-radius);
+    text-align: center;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+    transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.hub-organiser-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.12);
+}
+
+.hub-organiser-card h4 {
+    color: var(--primary-color);
+    font-size: 1.2rem;
+    margin-bottom: 0.5rem;
+}
+
+.hub-organiser-card .hub-affiliation {
+    color: var(--dark-gray);
+    font-size: 0.95rem;
+    font-style: italic;
+}
+
 /* Footer */
 footer {
     background-color: var(--secondary-color);
@@ -531,5 +621,45 @@ footer .social-links a:hover {
     /* Map responsive */
     #hub-map {
         height: 300px;
+    }
+
+    /* Organisers responsive */
+    .organisers-content {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .organiser-card {
+        padding: 1.5rem;
+    }
+
+    .organiser-card h3 {
+        font-size: 1.3rem;
+    }
+
+    .organiser-card .affiliation {
+        font-size: 1rem;
+    }
+
+    .organiser-card .email {
+        font-size: 0.9rem;
+    }
+
+    /* Local Hub Organisers responsive */
+    .local-hub-organisers-content {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .hub-organiser-card {
+        padding: 1rem;
+    }
+
+    .hub-organiser-card h4 {
+        font-size: 1.1rem;
+    }
+
+    .hub-organiser-card .hub-affiliation {
+        font-size: 0.9rem;
     }
 }

--- a/index.html
+++ b/index.html
@@ -72,32 +72,20 @@
                             <tr>
                                 <th>Country</th>
                                 <th>City</th>
-                                <th>Contact Person</th>
-                                <th>Address</th>
-                                <th>Email/Phone</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
                                 <td>Egypt</td>
                                 <td>Cairo</td>
-                                <td>Prof. Aya Yassin</td>
-                                <td>Ain Shams University</td>
-                                <td>ayassin@med.asu.edu.eg</td>
                             </tr>
                             <tr>
                                 <td>Nigeria</td>
                                 <td>Lagos</td>
-                                <td>Charity Umoren</td>
-                                <td>120/124 Ikorodu Road Igbobi, Lagos, Nigeria</td>
-                                <td>udunna.anazodo@mcgill.ca, madewole@mailab.io</td>
                             </tr>
                             <tr>
                                 <td>South Africa</td>
                                 <td>Cape Town</td>
-                                <td>Dr Frances Robertson</td>
-                                <td>University of Cape Town</td>
-                                <td>francesrob@gmail.com</td>
                             </tr>
                         </tbody>
                     </table>
@@ -110,25 +98,16 @@
                             <tr>
                                 <th>Country</th>
                                 <th>City</th>
-                                <th>Contact Person</th>
-                                <th>Address</th>
-                                <th>Email/Phone</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
                                 <td>Guatemala</td>
                                 <td>Guatemala City</td>
-                                <td>Andrea</td>
-                                <td>Universidad Galileo</td>
-                                <td>andrealh@galileo.edu</td>
                             </tr>
                             <tr>
                                 <td>Peru</td>
                                 <td>Lima</td>
-                                <td>Pedro Shiguihara</td>
-                                <td>Universidad San Ignacio de Loyola</td>
-                                <td>p.shiguihara@gmail.com</td>
                             </tr>
                         </tbody>
                     </table>
@@ -141,39 +120,24 @@
                             <tr>
                                 <th>Country</th>
                                 <th>City</th>
-                                <th>Contact Person</th>
-                                <th>Address</th>
-                                <th>Email/Phone</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
                                 <td>Oman</td>
                                 <td>Al-Seeb</td>
-                                <td>Fatma Al Raisi</td>
-                                <td>Oman Medical College</td>
-                                <td>ayman.alhaj@omc.edu.om</td>
                             </tr>
                             <tr>
                                 <td>Pakistan</td>
                                 <td>Lahore</td>
-                                <td>Waqas Sultani, Arif Mahmood and Mohsen Ali</td>
-                                <td>Information Technology</td>
-                                <td>waqas.sultani@itu.edu.pk, arif.mahmood@itu.edu.pk, mohsen.ali@itu.edu.pk</td>
                             </tr>
                             <tr>
                                 <td>Pakistan</td>
                                 <td>Khyber Pakhtunkhwa</td>
-                                <td>Khurram Jadoon</td>
-                                <td>Ghulam Ishaq Khan Institute of Engineering Sciences and Technology</td>
-                                <td>khurram.jadoon@giki.edu.pk</td>
                             </tr>
                             <tr>
                                 <td>Vietnam</td>
                                 <td>Hanoi</td>
-                                <td>Dr. Hieu Pham</td>
-                                <td>VinUniversity</td>
-                                <td>hieu.ph@vinuni.edu.vn</td>
                             </tr>
                         </tbody>
                     </table>
@@ -186,32 +150,24 @@
                             <tr>
                                 <th>Country</th>
                                 <th>City</th>
-                                <th>Contact Person</th>
-                                <th>Address</th>
-                                <th>Email/Phone</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
                                 <td>Jordan</td>
                                 <td>Amman</td>
-                                <td>Omar Alkadi</td>
-                                <td>University of Jordan</td>
-                                <td>O.Alkadi@ju.edu.jo</td>
                             </tr>
                             <tr>
                                 <td>Lebanon</td>
                                 <td>Beirut</td>
-                                <td>Razane Tajeddine, Ali Chehab</td>
-                                <td>American University of Beirut</td>
-                                <td>rt37@aub.edu.lb, chehab@aub.edu.lb</td>
+                            </tr>
+                            <tr>
+                                <td>Palestine</td>
+                                <td>City of Ramallah (Online)</td>
                             </tr>
                             <tr>
                                 <td>Syria</td>
                                 <td>Damascus</td>
-                                <td>Nada Ghneim</td>
-                                <td>Damascus University</td>
-                                <td>https://www.aiu.edu.sy/en/7780/Dr.-Nada-Ghuneim, Ibrahim.Almakky@mbzuai.ac.ae</td>
                             </tr>
                         </tbody>
                     </table>
@@ -451,6 +407,63 @@
                 </div>
             </div>
         </section>-->
+        <section id="organisers">
+            <div class="section-header">
+                <h2>RISE Summer School Organisers</h2>
+            </div>
+            <div class="organisers-content">
+                <div class="organiser-card">
+                    <h3>David Duenas-Gaviria</h3>
+                    <p class="affiliation">Summer/Winter Coordinator, PhD Candidate<br>Universitätsklinikum Bonn, Germany</p>
+                    <p class="email"><i class="fas fa-envelope"></i> <a href="mailto:David.Duenas-Gaviria@ukbonn.de">David.Duenas-Gaviria@ukbonn.de</a></p>
+                </div>
+                <div class="organiser-card">
+                    <h3>Baoru Huang</h3>
+                    <p class="affiliation">Assistant Professor<br>University of Liverpool, UK</p>
+                    <p class="email"><i class="fas fa-envelope"></i> <a href="mailto:baoru.huang@liverpool.ac.uk">baoru.huang@liverpool.ac.uk</a></p>
+                </div>
+            </div>
+        </section>
+
+        <section id="local-hub-organisers">
+            <div class="section-header">
+                <h2>Local Hub Organisers</h2>
+            </div>
+            <div class="local-hub-organisers-content">
+                <div class="hub-organiser-card">
+                    <h4>Andrea Lara</h4>
+                    <p class="hub-affiliation">Universidad Galileo</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Tareen Dawood</h4>
+                    <p class="hub-affiliation">Denmark Technical University</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Ibrahim Makky</h4>
+                    <p class="hub-affiliation">Mohamed bin Zayed University of Artificial Intelligence</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Shahad Hardan</h4>
+                    <p class="hub-affiliation">Mohamed bin Zayed University of Artificial Intelligence</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Rabia Haq</h4>
+                    <p class="hub-affiliation">3DR Labs</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Udunna Anazodo</h4>
+                    <p class="hub-affiliation">Department of Neurology and Neurosurgery at McGill</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Nhat Phung</h4>
+                    <p class="hub-affiliation">AstraZeneca</p>
+                </div>
+                <div class="hub-organiser-card">
+                    <h4>Maruf Adewole</h4>
+                    <p class="hub-affiliation">Medical Artificial Intelligence Laboratory (MAI Lab)</p>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer>

--- a/js/map.js
+++ b/js/map.js
@@ -18,6 +18,7 @@ const hubLocations = [
     // Middle East
     { city: "Damascus", country: "Syria", lat: 33.5138, lng: 36.2765 },
     { city: "Amman", country: "Jordan", lat: 31.9539, lng: 35.9106 },
+    { city: "City of Ramallah", country: "Palestine", lat: 31.9074, lng: 35.2043 },
     { city: "Beirut", country: "Lebanon", lat: 33.8938, lng: 35.5018 }
 ];
 
@@ -62,9 +63,14 @@ function initializeHubMap() {
     
     // Add markers for each hub location
     hubLocations.forEach(location => {
+        // Add "(Online)" label for City of Ramallah
+        const label = location.city === "City of Ramallah" 
+            ? `${location.city} (Online), ${location.country}`
+            : `${location.city}, ${location.country}`;
+            
         const marker = L.marker([location.lat, location.lng], { icon: markerIcon })
             .addTo(map)
-            .bindTooltip(`${location.city}, ${location.country}`, {
+            .bindTooltip(label, {
                 permanent: false,
                 direction: 'top',
                 offset: [0, -40]


### PR DESCRIPTION
## Summary
- Added RISE Summer School Organisers section featuring David Duenas-Gaviria and Baoru Huang with their complete information
- Added Local Hub Organisers section with all 8 hub coordinators
- Updated hub location tables for better readability
- Added Palestine hub location with online designation

## Changes Made

### 1. Added Organisers Sections
- **RISE Summer School Organisers**: Added section with David Duenas-Gaviria (Summer/Winter Coordinator, PhD Candidate at Universitätsklinikum Bonn) and Baoru Huang (Assistant Professor at University of Liverpool)
- **Local Hub Organisers**: Added section with 8 hub coordinators including their affiliations

### 2. Updated Hub Location Tables
- Simplified tables to only show Country and City columns (removed Contact Person, Address, Email/Phone)
- Added Palestine with "City of Ramallah (Online)" to Middle East section
- Updated map.js to include City of Ramallah marker with "(Online)" tooltip

### 3. Styling
- Added responsive CSS for both organisers sections
- Cards with hover effects for better user experience
- Mobile-friendly responsive design

## Test Plan
- [x] Verify organisers sections display correctly on desktop
- [x] Check responsive design on mobile devices
- [x] Ensure map displays all hub locations including City of Ramallah
- [x] Verify "(Online)" label appears in tooltip for City of Ramallah

🤖 Generated with [Claude Code](https://claude.ai/code)